### PR TITLE
Contemplate pipeline toolkits

### DIFF
--- a/ReproducibleResearch.ctv
+++ b/ReproducibleResearch.ctv
@@ -147,7 +147,7 @@
     <h2>Pipeline Toolkits</h2>
 
 <p>
-    At a more basic level than scientific replicability, literate programming, and version control, reproducibility carries an implicit promise that the alleged results of an analysis really do match the code. Pipeline toolkits help keep this promise by tracking the relationships among the components of the analysis and reacting to changes in the dependencies. They can also carry <a href="https://cran.r-project.org/web/views/ReproducibleResearch.html">high-performance computing</a> benefits such as implicit parallelism and the ability to automatically skip computations that are already up to date. The <pkg>drake</pkg> package is an R-focused pipeline toolkit with all these benefits.
+    At a more basic level than scientific replicability, literate programming, and version control, reproducibility carries an implicit promise that the alleged results of an analysis really do match the code. Pipeline toolkits help keep this promise by tracking the relationships among the components of the analysis and reacting to changes in the dependencies. Some even carry <a href="https://cran.r-project.org/web/views/ReproducibleResearch.html">high-performance computing</a> benefits such as implicit parallelism and the ability to automatically skip computations that are already up to date. The <pkg>drake</pkg> package is an R-focused pipeline toolkit with all these benefits.
 </p>
 <p>
 The general approach of a <a href="https://github.com/pditommaso/awesome-pipeline">pipline toolkit</a> is ubiquitous in the Python world, and it is starting to gain traction in the R community, particularly in the <a href="https://peerj.com/preprints/3210/">opinionated analysis development paradigm</a>.

--- a/ReproducibleResearch.ctv
+++ b/ReproducibleResearch.ctv
@@ -7,7 +7,7 @@
   
   <info>
     <p>
-      The goal of reproducible research is to tie specific instructions to data analysis and experimental data so that scholarship can be recreated, better understood and verified. Packages in R for this purpose can be split into groups for: literate programming, package reproducibility, code/data formatting tools, format convertors, and object caching. 
+      The goal of reproducible research is to tie specific instructions to data analysis and experimental data so that scholarship can be recreated, better understood and verified. Packages in R for this purpose can be split into groups for: literate programming, pipeline toolkits, package reproducibility, code/data formatting tools, format convertors, and object caching. 
     </p>
     <h1>Literate Programming</h1>
     <p>
@@ -144,6 +144,15 @@
      Miscellaneous Tools
    </h1>     
 
+    <h2>Pipeline Toolkits</h2>
+
+<p>
+    At a more basic level than scientific replicability, literate programming, and version control, reproducibility carries an implicit promise that the alleged results of an analysis really do match the code. Pipeline toolkits help keep this promise by tracking the relationships among the components of the analysis and reacting to changes in the dependencies. They can also carry <a href="https://cran.r-project.org/web/views/ReproducibleResearch.html">high-performance computing</a> benefits such as implicit parallelism and the ability to automatically skip computations that are already up to date. The <pkg>drake</pkg> package is an R-focused pipeline toolkit with all these benefits.
+</p>
+<p>
+The general approach of a <a href="https://github.com/pditommaso/awesome-pipeline">pipline toolkit</a> is ubiquitous in the Python world, and it is starting to gain traction in the R community, particularly in the <a href="https://peerj.com/preprints/3210/">opinionated analysis development paradigm</a>.
+</p>
+
    <h2>Package Reproducibility</h2>    
    <p> 
      R also has tools for ensuring that specific packages versions can be required for analyses. <pkg>checkpoint</pkg>, <pkg>rbundler</pkg> and <pkg>packrat</pkg> install packages required for a project to a local archive as they existed at a specified point in time. This allows specific package versions to be maintained over time and different users. The <pkg>miniCRAN</pkg> package facilitates the creation of local CRAN-like repositories. 
@@ -167,7 +176,7 @@
     When using <code>Sweave</code> and <pkg>knitr</pkg> it can be advantageous to <i>cache</i> the results of time consuming code chunks if the document will be re-processed (i.e. during debugging). <pkg>knitr</pkg> facilitates object caching and the Bioconductor package <bioc>weaver</bioc> can be used with <code>Sweave</code>.
    </p>   
    <p>
-   Non-literate programming packages to facilitating caching/archiving are <pkg>R.cache</pkg>, <pkg>archivist</pkg>, <pkg>storr</pkg>, and <pkg>drake</pkg>.
+   Non-literate programming packages to facilitating caching/archiving are <pkg>R.cache</pkg>, <pkg>archivist</pkg>, and <pkg>storr</pkg>.
    </p>
 
   </info>

--- a/ReproducibleResearch.ctv
+++ b/ReproducibleResearch.ctv
@@ -167,7 +167,7 @@
     When using <code>Sweave</code> and <pkg>knitr</pkg> it can be advantageous to <i>cache</i> the results of time consuming code chunks if the document will be re-processed (i.e. during debugging). <pkg>knitr</pkg> facilitates object caching and the Bioconductor package <bioc>weaver</bioc> can be used with <code>Sweave</code>.
    </p>   
    <p>
-   Non-literate programming packages to facilitating caching/archiving are <pkg>R.cache</pkg>, <pkg>archivist</pkg>, and <pkg>drake</pkg>.
+   Non-literate programming packages to facilitating caching/archiving are <pkg>R.cache</pkg>, <pkg>archivist</pkg>, <pkg>storr</pkg>, and <pkg>drake</pkg>.
    </p>
 
   </info>
@@ -234,6 +234,7 @@
     <pkg>SortableHTMLTables</pkg>
     <pkg>sparktex</pkg>
     <pkg>stargazer</pkg>
+    <pkg>storr</pkg>
     <pkg>suRtex</pkg>
     <pkg>SweaveListingUtils</pkg>
     <pkg>tables</pkg>


### PR DESCRIPTION
To my knowledge, the [drake package](https://github.com/wlandau-lilly/drake) is the most R-focused and [tidyverse-friendly](https://www.tidyverse.org/) [reproducible pipeline toolkit](https://github.com/pditommaso/awesome-pipeline), and the only one on CRAN. [Opinionated analysis development](https://peerj.com/preprints/3210/) contemplates the need, but I believe the list of tools needs to be updated.