### PR TITLE
Mentioned good packages for dealing with Microsoft/LibreOffice documents

### DIFF
--- a/ReproducibleResearch.ctv
+++ b/ReproducibleResearch.ctv
@@ -129,14 +129,20 @@
     Microsoft Formats
    </h2>
    <p>
-    The <pkg>ReporteRs</pkg> (formerly R2DOCX) package can create <tt>docx</tt> and <tt>pptx</tt> files.  <pkg>R2wd</pkg> (windows only) can also create Word documents from scratch and <pkg>R2PPT</pkg> (also windows only) can create PowerPoint slides. The <pkg>rtf</pkg> package does the same for Rich Text Format documents. 
+    The <pkg>officer</pkg> package can create <tt>docx</tt> and <tt>pptx</tt> files.  <pkg>R2wd</pkg> (windows only) can also create Word documents from scratch and <pkg>R2PPT</pkg> (also windows only) can create PowerPoint slides. The <pkg>rtf</pkg> package does the same for Rich Text Format documents. The <pkg>openxlsx</pkg> package creates <tt>xlsx</tt> files. The <pkg>export</pkg> package is built on top of <pkg>officer</pkg> and <pkg>openxlsx</pkg> and saves tables and graphical output to Word, PowerPoint, and Excel documents.
    </p>
    <p>
     Object Conversion Functions:
    </p>
    <ul>   
     <li>
-      <i>tables/cross-tabulations</i>: <pkg>apaStyle</pkg>
+      <i>tables/cross-tabulations</i>: <pkg>apaStyle</pkg>, <pkg>export</pkg>
+    </li>
+    <li>
+      <i>graphics</i>: <pkg>mschart</pkg>, <pkg>export</pkg>
+    </li>
+    <li>
+      <i>summary tables/statistics</i>: <pkg>export</pkg>
     </li>
    </ul>  
 
@@ -195,6 +201,7 @@ The general approach of a <a href="https://github.com/pditommaso/awesome-pipelin
     <pkg>drake</pkg>
     <pkg>DT</pkg>
     <pkg>exams</pkg>
+    <pkg>export</pkg>
     <pkg>formatR</pkg>
     <pkg>formattable</pkg>   
     <pkg>highlight</pkg>    
@@ -219,6 +226,8 @@ The general approach of a <a href="https://github.com/pditommaso/awesome-pipelin
     <pkg>NMOF</pkg>
     <pkg>odfWeave</pkg>
     <pkg>odfWeave.survey</pkg>
+    <pkg>officer</pkg>
+    <pkg>openxlsx</pkg>
     <pkg>packrat</pkg>       
     <pkg>pander</pkg>
     <pkg>papeR</pkg>
@@ -234,7 +243,6 @@ The general approach of a <a href="https://github.com/pditommaso/awesome-pipelin
     <pkg>rbundler</pkg>
     <pkg>RefManageR</pkg>
     <pkg>reporttools</pkg>    
-    <pkg>ReporteRs</pkg>
     <pkg>resumer</pkg>
     <pkg>rmarkdown</pkg>
     <pkg priority="core">rms</pkg>

--- a/ReproducibleResearch.ctv
+++ b/ReproducibleResearch.ctv
@@ -27,7 +27,7 @@
       </p>
         <ul>
           <li>
-            <i>summary tables/statistics</i>: <pkg>Hmisc</pkg>, <pkg>NMOF</pkg>, <pkg>papeR</pkg>, <pkg>quantreg</pkg>, <pkg>rapport</pkg>, <pkg>reporttools</pkg>, <pkg>sparktex</pkg>, <pkg>tables</pkg>,<pkg>xtable</pkg>, <pkg>ztable</pkg>
+            <i>summary tables/statistics</i>: <pkg>Hmisc</pkg>, <pkg>NMOF</pkg>, <pkg>papeR</pkg>, <pkg>quantreg</pkg>, <pkg>rapport</pkg>, <pkg>reporttools</pkg>, <pkg>sparktex</pkg>, <pkg>tables</pkg>,<pkg>xtable</pkg>, <pkg>ztable</pkg>, <pkg>export</pkg>
           </li>    
           <li>
             <i>tables/cross-tabulations</i>: <pkg>compareGroups</pkg>, <pkg>Hmisc</pkg>, <pkg>lazyWeave</pkg>, <pkg>knitLatex</pkg>, <pkg>knitr</pkg>, <pkg>reporttools</pkg>, <pkg>ztable</pkg>
@@ -64,7 +64,7 @@
       </p>
         <ul>
           <li>
-            <i>summary tables/statistics</i>: <pkg>stargazer</pkg>
+            <i>summary tables/statistics</i>: <pkg>stargazer</pkg>, <pkg>export</pkg>
           </li>    
           <li>
             <i>tables/cross-tabulations</i>: <pkg>compareGroups</pkg>, <pkg>DT</pkg>,  <pkg>formattable</pkg>, <pkg>htmlTable</pkg>, <pkg>HTMLUtils</pkg>, <pkg>hwriter</pkg>, <pkg>Kmisc</pkg>, <pkg>knitr</pkg>, <pkg>lazyWeave</pkg>, <pkg>SortableHTMLTables</pkg>, <pkg>texreg</pkg>, <pkg>ztable</pkg>
@@ -111,7 +111,7 @@
       OpenDocument Format (ODF)
     </h2>
       <p>
-        The <pkg>odfWeave</pkg> package can process ODF files.  
+        The <pkg>odfWeave</pkg> package can process ODF files. 
       </p>
       <p>
         Object Conversion Functions:
@@ -126,7 +126,7 @@
         </ul>  
 
    <h2>
-    Microsoft Formats
+    Microsoft/LibreOffice Formats
    </h2>
    <p>
     The <pkg>officer</pkg> package can create <tt>docx</tt> and <tt>pptx</tt> files.  <pkg>R2wd</pkg> (windows only) can also create Word documents from scratch and <pkg>R2PPT</pkg> (also windows only) can create PowerPoint slides. The <pkg>rtf</pkg> package does the same for Rich Text Format documents. The <pkg>openxlsx</pkg> package creates <tt>xlsx</tt> files. The <pkg>export</pkg> package is built on top of <pkg>officer</pkg> and <pkg>openxlsx</pkg> and saves tables and graphical output to Word, PowerPoint, and Excel documents.

--- a/ReproducibleResearch.ctv
+++ b/ReproducibleResearch.ctv
@@ -129,7 +129,7 @@
     Microsoft/LibreOffice Formats
    </h2>
    <p>
-    The <pkg>officer</pkg> package can create <tt>docx</tt> and <tt>pptx</tt> files.  <pkg>R2wd</pkg> (windows only) can also create Word documents from scratch and <pkg>R2PPT</pkg> (also windows only) can create PowerPoint slides. The <pkg>rtf</pkg> package does the same for Rich Text Format documents. The <pkg>openxlsx</pkg> package creates <tt>xlsx</tt> files. The <pkg>export</pkg> package is built on top of <pkg>officer</pkg> and <pkg>openxlsx</pkg> and saves tables and graphical output to Word, PowerPoint, and Excel documents.
+    The <pkg>officer</pkg> package can create <tt>docx</tt> and <tt>pptx</tt> files.  <pkg>R2wd</pkg> (windows only) can also create Word documents from scratch and <pkg>R2PPT</pkg> (also windows only) can create PowerPoint slides. The <pkg>rtf</pkg> package does the same for Rich Text Format documents. The <pkg>openxlsx</pkg> package creates <tt>xlsx</tt> files. The <pkg>export</pkg> package is built on top of <pkg>officer</pkg> and <pkg>openxlsx</pkg> and saves tables and graphical output to <tt>docx</tt>, <tt>pptx</tt>, and <tt>xlsx</tt> documents.
    </p>
    <p>
     Object Conversion Functions:


### PR DESCRIPTION
I added a few packages ('officer', 'openxlsx', 'export') that are useful when dealing with Microsoft documents from R ("docx", "pptx", and "xlsx"). Note that 'ReporterRs' has been deleted and 'officer' should be used instead.
I also changed "Microsoft Formats" to "Microsoft/LibreOffice Formats" to point out that the packages apply not only to Word, PowerPoint, or Excel, but also to open access software.
I also mentioned 'export' for exporting tables and statistical summaries in LaTex and HTML format.